### PR TITLE
Add missing dependencies in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -11,5 +11,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>gazebo_ros</depend>
   <depend>gazebo_plugins</depend>
+  <depend>robot_state_publisher</depend>
+  <depend>joint_state_publisher</depend>
   <exec_depend>gazebo</exec_depend>
 </package>


### PR DESCRIPTION
`robot_state_publisher` and `joint_state_publisher` are required for `spawn_turtlebot.launch`, adding them into package.xml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
