### PR TITLE
Update param name for robot description

### DIFF
--- a/launch/spawn_turtlebot.launch
+++ b/launch/spawn_turtlebot.launch
@@ -11,9 +11,9 @@
   <arg name="yaw" default="0.0"/>
 
   <!-- Spawn the robot into Gazebo with the turtlebot description -->
-  <param name="robot_description" command="$(find xacro)/xacro --inorder $(find turtlebot3_description_reduced_mesh)/urdf/turtlebot3_$(arg model).urdf.xacro" />
+  <param name="robot_description_gazebo" command="$(find xacro)/xacro --inorder $(find turtlebot3_description_reduced_mesh)/urdf/turtlebot3_$(arg model).urdf.xacro" />
   <node pkg="gazebo_ros" type="spawn_model" name="spawn_urdf" 
-    args="-urdf -param robot_description -model turtlebot3_$(arg model)
+    args="-urdf -param robot_description_gazebo -model turtlebot3_$(arg model)
           -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) 
           -R $(arg roll) -P $(arg pitch) -Y $(arg yaw)"/>
 


### PR DESCRIPTION
Currently it create param for the reduced mesh robot description as "robot_description", which is also the name used by the rviz in the package turtlebot3_description, hence causing confusion.

This PR renames the param to "robot_description_gazebo" to avoid confusion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
