### PR TITLE
Remove robot_state_publisher in the launch file

### DIFF
--- a/launch/spawn_turtlebot.launch
+++ b/launch/spawn_turtlebot.launch
@@ -17,11 +17,6 @@
           -x $(arg x_pos) -y $(arg y_pos) -z $(arg z_pos) 
           -R $(arg roll) -P $(arg pitch) -Y $(arg yaw)"/>
 
-  <!-- 
-       Publish robot and joint states. This allows rviz to display robot data, and in 
-       the robot's coordinate frame. These nodes could go into the robot application 
-       .launch files instead.
-    -->
-  <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" output="screen"/>
+  <!-- Publish joint states -->
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>gazebo_ros</depend>
   <depend>gazebo_plugins</depend>
-  <depend>robot_state_publisher</depend>
   <depend>joint_state_publisher</depend>
   <exec_depend>gazebo</exec_depend>
 </package>


### PR DESCRIPTION
Remove `robot_state_publisher` from the launch file, which is often launched by simulation applications. `robot_state_publisher` should be moved to and launched in robot applications (which is being done in other repositories).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
