### PR TITLE
Remove get_default_launch_description

### DIFF
--- a/launch/spawn_turtlebot.launch.py
+++ b/launch/spawn_turtlebot.launch.py
@@ -22,7 +22,6 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch_ros import get_default_launch_description
 from ament_index_python.packages import get_package_share_directory
 
 


### PR DESCRIPTION
Removing `get_default_launch_description` from the launch file because it is not used anywhere.

Signed-off-by: Snehal Bichkar <snehaldb@amazon.com>

